### PR TITLE
Problem: tezos-run: curl fails without explanation

### DIFF
--- a/modules/tezos-run.sh.nix
+++ b/modules/tezos-run.sh.nix
@@ -16,7 +16,7 @@ set -o pipefail
 
 ulimit -v unlimited  # tezos does sparse allocation of terabytes of vm
 
-peerArgs=$(${curl}/bin/curl -s '${tzscanUrl}' | ${gnugrep}/bin/grep -Eo '::ffff:([0-9.:]+)' |
+peerArgs=$(${curl}/bin/curl -S '${tzscanUrl}' | ${gnugrep}/bin/grep -Eo '::ffff:([0-9.:]+)' |
   ${gnused}/bin/sed -e 's/::ffff://' | ${coreutils}/bin/sort -u |
   ${findutils}/bin/xargs ${coreutils}/bin/printf -- '--peer=%s ')
 exec ${kit}/bin/tezos-node run --data-dir "${configDir}" --rpc-addr localhost:${toString (8732 + index)} \


### PR DESCRIPTION
curl is too silent. We don't want the progress bar, but if it e.g. has
network issues, we need to see that in the log.

Solution: Use -S, not -s.