### PR TITLE
Problem: Zarith (so, Tezos) does not build in the Nix sandbox

### DIFF
--- a/pins/tezos-baking-platform/default.json
+++ b/pins/tezos-baking-platform/default.json
@@ -1,7 +1,7 @@
 {
   "url": "https://gitlab.com/clacke/tezos-baking-platform.git",
-  "rev": "3ae50693fdc75f501a71659f4066782feda779e5",
-  "date": "2018-10-16T18:27:30+08:00",
-  "sha256": "0n6bhvkvpdwvcsabhaj2cd16m2691hy97arszj1nq2ap4r092bs4",
-  "fetchSubmodules": false
+  "rev": "c1228a2ca7734e71a27daae0d0bbe566a32aed6f",
+  "date": "2018-10-31T19:34:19+08:00",
+  "sha256": "0afhapn4ma9rm9xpphsf4nwqc06wmza55225wlhg1mxpl3fykx85",
+  "fetchSubmodules": true
 }


### PR DESCRIPTION
That's because in the sandbox there is no /usr/bin/env.

Solution: Bump tezos-baking-platform.

 - Make all OPAM packages run patchShebangs in postPatch.
 - If any package redefines postPatch, the package's own postPatch
   takes priority.