### PR TITLE
Problem: baker-stats: Leaving outdated blocks around

### DIFF
--- a/modules/stakepool.nix
+++ b/modules/stakepool.nix
@@ -147,7 +147,7 @@ let
       script = import ./tezos-baker-stats.sh.nix {
         inherit index kit;
         inherit (current) bakerAddressAlias bakerDir bakerStatsExportDir;
-        inherit (pkgs) gawk jq;
+        inherit (pkgs) coreutils findutils gawk gnugrep jq;
       };
       startAt = "*:07";
     };

--- a/modules/tezos-baker-stats.sh.nix
+++ b/modules/tezos-baker-stats.sh.nix
@@ -1,7 +1,10 @@
 { bakerAddressAlias
 , bakerDir
 , bakerStatsExportDir
+, coreutils
+, findutils
 , gawk
+, gnugrep
 , index
 , jq
 , kit
@@ -56,4 +59,8 @@ for i in delegate baking_rights endorsing_rights; do
   rm -f "${bakerStatsExportDir}"/$i.json
   ln -s block/$head/$i.json "${bakerStatsExportDir}"/$i.json
 done
+
+${findutils}/bin/find "${bakerStatsExportDir}"/block -maxdepth 1 -path "${bakerStatsExportDir}/block/*" -print0 |
+  ${gnugrep}/bin/grep -zZvFf "${bakerStatsExportDir}"/blocks |
+  ${findutils}/bin/xargs -0 rm -rf
 ''


### PR DESCRIPTION
We always store and parse the head of the chain, but unless it happens
to be the last block of a cycle, it becomes irrelevant when the next
block comes around.

'blocks' holds the relevant blocks -- the current head and the last
blocks of all preceding cycles.

Solution: At the end of baker-stats, remove all cached blocks not in 'blocks'.