### PR TITLE
Problem: baker-stats: May fail to run, runs as root

### DIFF
--- a/modules/stakepool.nix
+++ b/modules/stakepool.nix
@@ -150,6 +150,7 @@ let
         inherit (pkgs) gawk jq;
       };
       serviceConfig = {
+        ExecStartPre = monitorBootstrapped;
         User = current.user;
       };
       startAt = "*:07";

--- a/modules/stakepool.nix
+++ b/modules/stakepool.nix
@@ -149,6 +149,9 @@ let
         inherit (current) bakerAddressAlias bakerDir bakerStatsExportDir;
         inherit (pkgs) gawk jq;
       };
+      serviceConfig = {
+        User = current.user;
+      };
       startAt = "*:07";
     };
   in


### PR DESCRIPTION
Solution: Run as baker user, wait for node to be up before running.