### PR TITLE
Problem: No modules/default.nix

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,0 +1,7 @@
+{ ... }:
+
+{
+  imports = [
+    ./stakepool.nix
+  ];
+}

--- a/stub-system/configuration.nix
+++ b/stub-system/configuration.nix
@@ -5,7 +5,7 @@ let inherit (import (import ../pins/nixpkgs) {}) lib; in
 
 {
   imports = [
-    ../modules/stakepool.nix
+    ../modules
   ];
 
   boot.isContainer = true;


### PR DESCRIPTION
Convention demands a modules.nix or a modules/default.nix.

Solution: Add modules/default.nix, which imports stakepools.nix.

Make the stub-system use modules instead of modules/stakepools.nix.