### PR TITLE
Problem: No per-account distributed rewards

### DIFF
--- a/modules/stakepool.nix
+++ b/modules/stakepool.nix
@@ -147,7 +147,7 @@ let
       script = import ./tezos-baker-stats.sh.nix {
         inherit index kit;
         inherit (current) bakerAddressAlias bakerDir bakerStatsExportDir;
-        inherit (pkgs) coreutils findutils gawk gnugrep jq;
+        inherit (pkgs) coreutils findutils gawk gnugrep jq tcl;
       };
       serviceConfig = {
         ExecStartPre = monitorBootstrapped;


### PR DESCRIPTION
Solution: Get all frozen rewards in history, calculate distribution.

Generate for each snapshot cycle rewards.json, collate in global
rewards.json.

The format is an array of objects with cycle, staker, reward, so this
is ready for being put in a table on the website.

Issues:
 - The distribution is based on the final level of each cycle,
   and can be gamed. Fairer would be a random sample -- not
   necessarily the same as the one Tezos chose, but it would have to
   at least be reproducible after the fact, but not predictable
   beforehand.
 - The fairest measure would be the average staking balance over the
   whole snapshot cycle, but that's expensive in storage and time.