### PR TITLE
Problem: tezos-init needs node running

### DIFF
--- a/modules/tezos-baker.sh.nix
+++ b/modules/tezos-baker.sh.nix
@@ -10,6 +10,11 @@ set -e
 set -u
 set -o pipefail
 
+if ! ${kit}/bin/tezos-client --base-dir "${bakerDir}" list known addresses | grep -E '^${bakerAddressAlias}: '; then
+  ${kit}/bin/tezos-client --base-dir "${bakerDir}" gen keys "${bakerAddressAlias}"
+  ${kit}/bin/tezos-client --base-dir "${bakerDir}" list known addresses | grep -E '^${bakerAddressAlias}: '
+fi
+
 exec ${kit}/bin/tezos-baker-002-PsYLVpVv --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
   run with local node "${configDir}" "${bakerAddressAlias}"
 ''

--- a/modules/tezos-init.sh.nix
+++ b/modules/tezos-init.sh.nix
@@ -27,10 +27,6 @@ ${if baking then ''
   mkdir -p "${bakerDir}"
   chown -R "${user}": "${bakerDir}"
   chmod 700 "${bakerDir}"
-  if ! ${kit}/bin/tezos-client --base-dir "${bakerDir}" list known addresses | grep -E '^${bakerAddressAlias}: '; then
-    ${runit}/bin/chpst -u "${user}" ${kit}/bin/tezos-client --base-dir "${bakerDir}" gen keys "${bakerAddressAlias}"
-    ${kit}/bin/tezos-client --base-dir "${bakerDir}" list known addresses | grep -E '^${bakerAddressAlias}: '
-  fi
 
   mkdir -p "${bakerStatsExportDir}"
   chown -R "${user}": "${bakerStatsExportDir}"


### PR DESCRIPTION
Generating the keys for the baker is done with an RPC call.

Solution: Move baker key gen to the baker service.

As an added benefit we don't need to switch users, because the service
is already running as the non-root user.