### PR TITLE
Problem: xargs cannot make use of a bash function

### DIFF
--- a/modules/tezos-baker-stats.sh.nix
+++ b/modules/tezos-baker-stats.sh.nix
@@ -113,8 +113,8 @@ for block in ''${blocks[*]}; do
 done
 
 printf "%s\n" ''${blocks[*]} | ${coreutils}/bin/tail -n +2 | ${coreutils}/bin/head -n -8 |
-  ${findutils}/bin/xargs printf "${bakerStatsExportDir}/block/%s/rewards.json\0" |
-  ${findutils}/bin/xargs -0 jq -s flatten > "${bakerStatsExportDir}"/rewards.json.new
+  ${findutils}/bin/xargs ${coreutils}/bin/printf "${bakerStatsExportDir}/block/%s/rewards.json\0" |
+  ${findutils}/bin/xargs -0 ${jq}/bin/jq -s flatten > "${bakerStatsExportDir}"/rewards.json.new
 ${coreutils}/bin/mv "${bakerStatsExportDir}"/rewards.json.new "${bakerStatsExportDir}"/rewards.json
 
 for i in delegate baking_rights endorsing_rights; do
@@ -124,5 +124,5 @@ done
 
 ${findutils}/bin/find "${bakerStatsExportDir}"/block -maxdepth 1 -path "${bakerStatsExportDir}/block/*" -print0 |
   ${gnugrep}/bin/grep -zZvFf "${bakerStatsExportDir}"/blocks |
-  ${findutils}/bin/xargs -0 rm -rf
+  ${findutils}/bin/xargs -0 ${coreutils}/bin/rm -rf
 ''


### PR DESCRIPTION
The jq function won't be used by xargs, so it will rely on PATH to
find jq.

Solution: Prefix jq with the absolute path when called with xargs.

 - Found an rm call that should have an absolute prefix.
 - printf is an internal bash command, but when used with xargs, it's
   the coreutils printf.