### PR TITLE
Problem: Baker account is compiled into the stats script.

### DIFF
--- a/modules/stakepool.nix
+++ b/modules/stakepool.nix
@@ -142,13 +142,16 @@ let
       };
     };
     stats-name = "tezos-${current.network}-baker-stats-${toString index}";
+    stats-script = pkgs.writeScript "tezos-baker-stats.sh" (import ./tezos-baker-stats.sh.nix {
+      inherit index kit;
+      inherit (current) bakerDir;
+      inherit (pkgs) coreutils findutils gawk gnugrep jq tcl;
+    });
     stats-value = {
       description = "Tezos ${current.network} baker stats export";
-      script = import ./tezos-baker-stats.sh.nix {
-        inherit index kit;
-        inherit (current) bakerAddressAlias bakerDir bakerStatsExportDir;
-        inherit (pkgs) coreutils findutils gawk gnugrep jq tcl;
-      };
+      script = ''
+        exec ${stats-script} "${current.bakerStatsExportDir}" "${current.bakerAddressAlias}"
+      '';
       serviceConfig = {
         ExecStartPre = monitorBootstrapped;
         User = current.user;


### PR DESCRIPTION
You cannot trivially run the stats on an arbitrary account.

Solution: Split out the stats script from the stats service.

Still not super convenient, but at least you can read the service,
read the service script, and then find the stats script and run it
with your choice of output dir and account address.

It's a first step.