### PR TITLE
Problem: baker-stats: The address lookup does not work

### DIFF
--- a/modules/tezos-baker-stats.sh.nix
+++ b/modules/tezos-baker-stats.sh.nix
@@ -33,9 +33,9 @@ function jq() {
 }
 
 if (( ''${#addressOrName} == 36 )) && [[ ${addressOrName:0:3} = "tz1" ]]; then
-  address=$(client show address "$addressOrName" | ${gawk}/bin/awk '$1 == "Hash:" { print $2 }')
-else
   address=$addressOrName
+else
+  address=$(client show address "$addressOrName" | ${gawk}/bin/awk '$1 == "Hash:" { print $2 }')
 fi
 
 head=$(client rpc get /chains/main/blocks/head/hash | jq . -r)


### PR DESCRIPTION
The addressOrName conditional is exactly backwards.

We make an address lookup when we get a literal address:

    Error:
      Erroneous command line argument 3 (tz1...).
      no public key hash alias named tz1...

And we use the alias in RPC calls when we get an address alias:

    Error:
      Did not find service

Solution: Correct the literal address detection.