### PR TITLE
Problem: Does not build with nixos-unstable

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -5,5 +5,8 @@
 
 lib.makeScope newScope (self: with self; {
   backerei-src = import ../pins/backerei;
-  inherit (callPackage (backerei-src + /release.nix) {}) backerei;
+  inherit (callPackage (backerei-src + /release.nix) {
+    compiler = if pkgs.haskell.packages ? ghc844 then pkgs.haskell.packages.ghc844
+      else pkgs.haskell.packages.ghc843;
+  }) backerei;
 })


### PR DESCRIPTION
    error: attribute 'ghc843' missing, at /nix/store/1ihy9p4cf2y2dpfr03bg5m3li26w9q8c-source/release.nix:4:14

This is when building Bäckerei.

Solution: Override the compiler, use ghc844 if available.