### PR TITLE
Problem: nixos-18.03 is not compatible with tezos-baking-platform

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -21,7 +21,6 @@ let
 in
 genJobs null pinnedNixos // {
   unstable = genJobs <nixpkgs> <nixpkgs/nixos>;
-  oldstable = genJobs <nixos-oldstable> <nixos-oldstable/nixos>;
   stable = genJobs <nixos-stable> <nixos-stable/nixos>;
   nixos-unstable = genJobs <nixos-unstable> <nixos-unstable/nixos>;
 } // (import <nixpkgs> {}).lib.optionalAttrs isTravis {


### PR DESCRIPTION
The lib.versioning fix in obsidian.systems/tezos-baking-platform#23 [0]
requires a nixpkgs from 2018-04 or later.

Solution: Remove nixos-oldstable from release.nix.

[0] https://gitlab.com/obsidian.systems/tezos-baking-platform/merge_requests/23
[0] https://github.com/fractalide/tezos-baking-platform/commit/3cfde6c9b068b57a09c576f14e0ec5f79e7e1157