### PR TITLE
 Problem: Not updated for protocol 003-PsddFKi3

### DIFF
--- a/modules/stakepool.nix
+++ b/modules/stakepool.nix
@@ -120,6 +120,22 @@ let
         User = current.user;
       };
     };
+    accuser-name-old = "tezos-${current.network}-accuser-old-${toString index}";
+    accuser-value-old = {
+      description = "Tezos ${current.network} accuser (legacy)";
+      script = callPackage ./tezos-accuser-old.sh.nix {
+        inherit index kit;
+        inherit (current) bakerDir;
+      };
+      wantedBy = [ "multi-user.target" ];
+      after = [ "${run-name}.service" ];
+      wants = [ "${run-name}.service" ];
+      serviceConfig = {
+        ExecStartPre = monitorBootstrapped;
+        Restart = "always";
+        User = current.user;
+      };
+    };
     baker-name = "tezos-${current.network}-baker-${toString index}";
     baker-value = {
       description = "Tezos ${current.network} baker";
@@ -136,10 +152,42 @@ let
         User = current.user;
       };
     };
+    baker-name-old = "tezos-${current.network}-baker-old-${toString index}";
+    baker-value-old = {
+      description = "Tezos ${current.network} baker (legacy)";
+      script = callPackage ./tezos-baker-old.sh.nix {
+        inherit index kit;
+        inherit (current) bakerAddressAlias bakerDir configDir;
+      };
+      wantedBy = [ "multi-user.target" ];
+      after = [ "${run-name}.service" ];
+      wants = [ "${run-name}.service" ];
+      serviceConfig = {
+        ExecStartPre = monitorBootstrapped;
+        Restart = "always";
+        User = current.user;
+      };
+    };
     endorser-name = "tezos-${current.network}-endorser-${toString index}";
     endorser-value = {
       description = "Tezos ${current.network} endorser";
       script = callPackage ./tezos-endorser.sh.nix {
+        inherit index kit;
+        inherit (current) bakerAddressAlias bakerDir;
+      };
+      wantedBy = [ "multi-user.target" ];
+      after = [ "${run-name}.service" ];
+      wants = [ "${run-name}.service" ];
+      serviceConfig = {
+        ExecStartPre = monitorBootstrapped;
+        Restart = "always";
+        User = current.user;
+      };
+    };
+    endorser-name-old = "tezos-${current.network}-endorser-old-${toString index}";
+    endorser-value-old = {
+      description = "Tezos ${current.network} endorser (legacy)";
+      script = callPackage ./tezos-endorser-old.sh.nix {
         inherit index kit;
         inherit (current) bakerAddressAlias bakerDir;
       };
@@ -178,6 +226,9 @@ let
       "${baker-name}" = baker-value;
       "${endorser-name}" = endorser-value;
       "${stats-name}" = stats-value;
+      "${accuser-name-old}" = accuser-value-old;
+      "${baker-name-old}" = baker-value-old;
+      "${endorser-name-old}" = endorser-value-old;
     });
 in
 {

--- a/modules/tezos-accuser-old.sh.nix
+++ b/modules/tezos-accuser-old.sh.nix
@@ -1,0 +1,13 @@
+{ bakerDir
+, index
+, kit
+}:
+
+''
+set -e
+set -u
+set -o pipefail
+
+exec ${kit}/bin/tezos-accuser-002-PsYLVpVv --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
+  run
+''

--- a/modules/tezos-accuser.sh.nix
+++ b/modules/tezos-accuser.sh.nix
@@ -8,6 +8,6 @@ set -e
 set -u
 set -o pipefail
 
-exec ${kit}/bin/tezos-accuser-002-PsYLVpVv --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
+exec ${kit}/bin/tezos-accuser-003-PsddFKi3 --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
   run
 ''

--- a/modules/tezos-baker-old.sh.nix
+++ b/modules/tezos-baker-old.sh.nix
@@ -15,6 +15,6 @@ if ! ${kit}/bin/tezos-client --base-dir "${bakerDir}" list known addresses | gre
   ${kit}/bin/tezos-client --base-dir "${bakerDir}" list known addresses | grep -E '^${bakerAddressAlias}: '
 fi
 
-exec ${kit}/bin/tezos-baker-003-PsddFKi3 --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
+exec ${kit}/bin/tezos-baker-002-PsYLVpVv --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
   run with local node "${configDir}" "${bakerAddressAlias}"
 ''

--- a/modules/tezos-endorser-old.sh.nix
+++ b/modules/tezos-endorser-old.sh.nix
@@ -1,0 +1,14 @@
+{ bakerAddressAlias
+, bakerDir
+, index
+, kit
+}:
+
+''
+set -e
+set -u
+set -o pipefail
+
+exec ${kit}/bin/tezos-endorser-002-PsYLVpVv --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
+  run "${bakerAddressAlias}"
+''

--- a/modules/tezos-endorser.sh.nix
+++ b/modules/tezos-endorser.sh.nix
@@ -9,6 +9,6 @@ set -e
 set -u
 set -o pipefail
 
-exec ${kit}/bin/tezos-endorser-002-PsYLVpVv --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
+exec ${kit}/bin/tezos-endorser-003-PsddFKi3 --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
   run "${bakerAddressAlias}"
 ''

--- a/pins/tezos-baking-platform/bump.sh
+++ b/pins/tezos-baking-platform/bump.sh
@@ -3,16 +3,21 @@
 
 set -euo pipefail
 
-URL=https://gitlab.com/clacke/tezos-baking-platform.git
-DEFAULT_REV=refs/heads/develop
-
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-rev=${1:-$DEFAULT_REV}
+url_pattern='[^"]*"url": "([^"]*)"'
+url=
+while IFS='' read -r line; do
+  [[ $line =~ $url_pattern ]] || continue
+  url=${BASH_REMATCH[1]}
+  break
+done < default.json
+
+rev=${1:-HEAD}
 
 if (( ${#rev} != 40 )); then
-  rev=$(git ls-remote $URL | awk '$2 == "'"$rev"'" { print $1 }')
+  rev=$(git ls-remote $url "$rev" | awk '{ print $1 }')
 fi
 
-nix-prefetch-git $URL $rev > default.json.new
+nix-prefetch-git $url $rev > default.json.new
 mv default.json{.new,}

--- a/pins/tezos-baking-platform/default.json
+++ b/pins/tezos-baking-platform/default.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://gitlab.com/clacke/tezos-baking-platform.git",
-  "rev": "c1228a2ca7734e71a27daae0d0bbe566a32aed6f",
-  "date": "2018-10-31T19:34:19+08:00",
-  "sha256": "0afhapn4ma9rm9xpphsf4nwqc06wmza55225wlhg1mxpl3fykx85",
-  "fetchSubmodules": true
+  "url": "https://github.com/fractalide/tezos-baking-platform",
+  "rev": "8c492b67de94802c1c4543d7ca00263e8190f7eb",
+  "date": "2018-11-26T16:35:40+08:00",
+  "sha256": "0pnjxxmdhg5vv9vk3ssmlprl6mh7gh2abrshmjfzwwssd2lpdnx2",
+  "fetchSubmodules": false
 }


### PR DESCRIPTION


Solution: Bump fractalide/tezos-baking-platform#8 .

 - Use the new and shorter bump.sh from
   fractalide/tezos-baking-platform , which is entirely generic
   instead of having embedded configuration.
 - To change where the pin is pointing, just do a 'nix-prefetch-git'
   to the JSON and bump.sh will pick it up next time.

----

 Problem: accuser baker endorser: old protocol

Solution: Run the binaries for the new protocol.

The old protocol is safe to run in parallel, the services will become
inactive at fork time. We'll remove them again when this has happened.

I'm adding some copy-paste for this emergency fix. Next time this
happens, we'll have something neater in store.