### PR TITLE
Problem: tezos-bake-platform bumped

### DIFF
--- a/pins/tezos-baking-platform/default.json
+++ b/pins/tezos-baking-platform/default.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/fractalide/tezos-baking-platform",
-  "rev": "8c492b67de94802c1c4543d7ca00263e8190f7eb",
-  "date": "2018-11-26T16:35:40+08:00",
-  "sha256": "0pnjxxmdhg5vv9vk3ssmlprl6mh7gh2abrshmjfzwwssd2lpdnx2",
+  "rev": "0aa7440eeb2ab1fcf2994724101d9554103dcf30",
+  "date": "2018-12-01T14:15:41-03:00",
+  "sha256": "1axvypfbkih6hcvib8m081y5ixfqhyyybvva5f3mb4kgld3gmjfi",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Solution: pull in our latest n greatest which contains these fixes

003/Baker: fix nonce revelation from old 002 blocks
Baker: prevent nonces revelation to crash the baker