### PR TITLE
Problem: No top-level default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,7 @@
+{ callPackage ? pkgs.callPackage
+, pkgs ? import (import ./pins/nixpkgs) {}
+}:
+
+{
+  modules = callPackage ./modules {};
+}


### PR DESCRIPTION
This means dependents need to do things like:

    imports = [ ((import pins/fractalpools) + "/modules") ];

(where pins/fractalpools is some `fetchgit { . . . }`)

Solution: Make ./modules an attribute 'modules' at the top level.

Now you can depend with an auto-importing pin and just:

    imports = [ (import pins/fractalpools).modules ];

(where pins/fractalpools is some `import (fetchgit { . . . })`)

It also helps with restrict-eval issues.